### PR TITLE
Fix duplicate estimates

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,9 +13,9 @@
     "skill/valory/abstract_abci/0.1.0": "bafybeiagrbn76jal52v2egtuwelcam3e2huzc6pwjtux2dh5hktxn7em3y",
     "connection/valory/p2p_libp2p_client/0.1.0": "bafybeihf35zfr35qsvfte4vbi7njvuzfx4httysw7owmlux53gvxh2or54",
     "skill/valory/abstract_round_abci/0.1.0": "bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy",
-    "skill/valory/apy_estimation_abci/0.1.0": "bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq",
+    "skill/valory/apy_estimation_abci/0.1.0": "bafybeianf55xqo3llhqedxzztvxwntue67jhagpwauu4t23ycox6fywiby",
     "skill/valory/registration_abci/0.1.0": "bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm",
-    "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeicjx2ke7jnaaqofsrouar32enw2b22z5uajkd5beazibwko2loupi",
-    "agent/valory/apy_estimation/0.1.0": "bafybeictt6g7uwkmhuzo6a4kigf65qodmz5rmpwfyrwpopkqzvsf5vn2hq",
-    "service/valory/apy_estimation/0.1.0": "bafybeiedtyzzfwimeixl4cd2dgbc5b2gt2rmbqzjwkzthudnpnhmp2lr6i"
+    "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeibq4cahrf4zjoa4cu2dlywnxdqwinwwdve4o7wpl7dw3tgw5exmsq",
+    "agent/valory/apy_estimation/0.1.0": "bafybeica3jgxobgbjdrf3txlovx3i3c7sg5itggjny7l5aqkvezxsrshwa",
+    "service/valory/apy_estimation/0.1.0": "bafybeieg2rlgu4vqus4imlqj7rxgad343swks42ydz4fpakwaurs72ltvq"
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,9 +13,9 @@
     "skill/valory/abstract_abci/0.1.0": "bafybeiagrbn76jal52v2egtuwelcam3e2huzc6pwjtux2dh5hktxn7em3y",
     "connection/valory/p2p_libp2p_client/0.1.0": "bafybeihf35zfr35qsvfte4vbi7njvuzfx4httysw7owmlux53gvxh2or54",
     "skill/valory/abstract_round_abci/0.1.0": "bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy",
-    "skill/valory/apy_estimation_abci/0.1.0": "bafybeidzqjl6kbawjuh26gk7glcnhqifhqxs3rrli6i47r627en4dnhy5m",
+    "skill/valory/apy_estimation_abci/0.1.0": "bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq",
     "skill/valory/registration_abci/0.1.0": "bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm",
-    "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeifkoegkmhzqw2456bkfufztyjr7wxzosunqujhil2dvhnel6y42om",
-    "agent/valory/apy_estimation/0.1.0": "bafybeidxc6uc6mpdtq5mfsvrl36bmgmds6kjxn7m452nu3nopikkblt5y4",
-    "service/valory/apy_estimation/0.1.0": "bafybeicgmidc56sm36omqp3ldo6662qdbdep3deb6xnx52qzl2u4s5nsq4"
+    "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeicjx2ke7jnaaqofsrouar32enw2b22z5uajkd5beazibwko2loupi",
+    "agent/valory/apy_estimation/0.1.0": "bafybeictt6g7uwkmhuzo6a4kigf65qodmz5rmpwfyrwpopkqzvsf5vn2hq",
+    "service/valory/apy_estimation/0.1.0": "bafybeiedtyzzfwimeixl4cd2dgbc5b2gt2rmbqzjwkzthudnpnhmp2lr6i"
 }

--- a/packages/valory/agents/apy_estimation/aea-config.yaml
+++ b/packages/valory/agents/apy_estimation/aea-config.yaml
@@ -28,8 +28,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeiagrbn76jal52v2egtuwelcam3e2huzc6pwjtux2dh5hktxn7em3y
 - valory/abstract_round_abci:0.1.0:bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy
-- valory/apy_estimation_abci:0.1.0:bafybeidzqjl6kbawjuh26gk7glcnhqifhqxs3rrli6i47r627en4dnhy5m
-- valory/apy_estimation_chained_abci:0.1.0:bafybeifkoegkmhzqw2456bkfufztyjr7wxzosunqujhil2dvhnel6y42om
+- valory/apy_estimation_abci:0.1.0:bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq
+- valory/apy_estimation_chained_abci:0.1.0:bafybeicjx2ke7jnaaqofsrouar32enw2b22z5uajkd5beazibwko2loupi
 - valory/registration_abci:0.1.0:bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/agents/apy_estimation/aea-config.yaml
+++ b/packages/valory/agents/apy_estimation/aea-config.yaml
@@ -28,8 +28,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeiagrbn76jal52v2egtuwelcam3e2huzc6pwjtux2dh5hktxn7em3y
 - valory/abstract_round_abci:0.1.0:bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy
-- valory/apy_estimation_abci:0.1.0:bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq
-- valory/apy_estimation_chained_abci:0.1.0:bafybeicjx2ke7jnaaqofsrouar32enw2b22z5uajkd5beazibwko2loupi
+- valory/apy_estimation_abci:0.1.0:bafybeianf55xqo3llhqedxzztvxwntue67jhagpwauu4t23ycox6fywiby
+- valory/apy_estimation_chained_abci:0.1.0:bafybeibq4cahrf4zjoa4cu2dlywnxdqwinwwdve4o7wpl7dw3tgw5exmsq
 - valory/registration_abci:0.1.0:bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/services/apy_estimation/service.yaml
+++ b/packages/valory/services/apy_estimation/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibhbkelnxxvsln677imq65vgbglmlhyxtax4iqtzempjiwcoef3gq
 fingerprint_ignore_patterns: []
-agent: valory/apy_estimation:0.1.0:bafybeidxc6uc6mpdtq5mfsvrl36bmgmds6kjxn7m452nu3nopikkblt5y4
+agent: valory/apy_estimation:0.1.0:bafybeictt6g7uwkmhuzo6a4kigf65qodmz5rmpwfyrwpopkqzvsf5vn2hq
 number_of_agents: 4
 ---
 public_id: valory/apy_estimation_abci:0.1.0

--- a/packages/valory/services/apy_estimation/service.yaml
+++ b/packages/valory/services/apy_estimation/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibhbkelnxxvsln677imq65vgbglmlhyxtax4iqtzempjiwcoef3gq
 fingerprint_ignore_patterns: []
-agent: valory/apy_estimation:0.1.0:bafybeictt6g7uwkmhuzo6a4kigf65qodmz5rmpwfyrwpopkqzvsf5vn2hq
+agent: valory/apy_estimation:0.1.0:bafybeica3jgxobgbjdrf3txlovx3i3c7sg5itggjny7l5aqkvezxsrshwa
 number_of_agents: 4
 ---
 public_id: valory/apy_estimation_abci:0.1.0

--- a/packages/valory/skills/apy_estimation_abci/behaviours.py
+++ b/packages/valory/skills/apy_estimation_abci/behaviours.py
@@ -1298,7 +1298,7 @@ class UpdateForecasterBehaviour(APYEstimationBaseBehaviour):
         """Initialize Behaviour."""
         super().__init__(**kwargs)
         self._async_result: Optional[AsyncResult] = None
-        self._y: Optional[PoolIdToTrainDataType] = None
+        self._y: Optional[pd.DataFrame] = None
         self._forecasters: Optional[PoolIdToForecasterType] = None
         self._models_hash: Optional[str] = None
 

--- a/packages/valory/skills/apy_estimation_abci/ml/forecasting.py
+++ b/packages/valory/skills/apy_estimation_abci/ml/forecasting.py
@@ -305,7 +305,7 @@ def update_forecaster_per_pool(
     :param forecasters: the forecasters to update.
     """
     for id_ in forecasters.keys():
-        apy = y.loc[y["id"] == id_.replace(".joblib", ".csv"), "APY"]
+        apy = y.loc[y["id"] == id_.replace(".joblib", ""), "APY"]
         forecasters[id_].update(apy)
 
 

--- a/packages/valory/skills/apy_estimation_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_abci/skill.yaml
@@ -31,7 +31,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiab5la63tomj6272c727vo6fq2ltdatbbs4nglwj4te3ghdyli7sa
   tests/test_handlers.py: bafybeigcoykpzwmbh5hbwub3bx4lr4fwutstqmbjahqpwx3zwu5ing75de
   tests/test_ml/__init__.py: bafybeigluuyaz73cej42yohuvoxnrx65hqsqoqmpzgof4b7co246s3jxjy
-  tests/test_ml/test_forecasting.py: bafybeif3rak7lvxmwvwtqprgqotbarx3f3m3u2knldchsm7nwbwly3srva
+  tests/test_ml/test_forecasting.py: bafybeif3zrpv4cxiondiok7gutqq2er56bodsyjdoe4lvxwrjzb3udkhvi
   tests/test_ml/test_optimization.py: bafybeihnvcgqttwmbi2idvmkrrd5becqry4bannzuww6webxfuznjocdfy
   tests/test_ml/test_preprocessing.py: bafybeicqer5b6fhzoimtrk4mwmh62km6olwljmhxvi6p7zdm6o4jbycfji
   tests/test_models.py: bafybeiaj6uv2dymuhmzqd3gqhdlheeoizzpdlmlemskqwci7q4dif4szxm

--- a/packages/valory/skills/apy_estimation_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeiceds6hedhgipxihnl2qt7i2woxsn4fw5ue3evm4aqvknjfpwnbay
   __init__.py: bafybeif4et2adwa4mtx4clsfcpqk77w23kdq5642vulkddnrsxms6ngbma
-  behaviours.py: bafybeicynie4vu3lu5tvjqd4nwimulfro5fuq3fidiski6xdmnaoniwnhm
+  behaviours.py: bafybeiebloygfrfvha4lyjdd3cemlnbpuvuxoh3ecxy2t4hafc27x26324
   constants.py: bafybeibx3m2zjvyq5gdqjhjqnqtenmub47mvtokrfzscrc5loqoy2f5pii
   dialogues.py: bafybeig4tc4thbpsixmbn35kj7jim2gzd7cvxxu4u3xoeyxqzpumuhrdzm
   fsm_specification.yaml: bafybeid56g5zov7zb2hnauahbejn5k3ilymrbg2aihhybzvzwdhbbctexq
@@ -17,7 +17,7 @@ fingerprint:
   io_/load.py: bafybeicmhoscwsihvu2gjeuabl74vme2ur36g7w6xczf2exuiozbzzwtsq
   io_/store.py: bafybeibjo6uaq4ikorbj4r2osqrcabed23tgxzzgwsuwf37w24o3vo5cfq
   ml/__init__.py: bafybeibceypb22objsuli3abse3rgyycs4hodokjfj5oei4ms4xlqkra5a
-  ml/forecasting.py: bafybeid4tmpqyktsdb76x5265y4duw4kxb76pa66zfceggrbzcju73esmi
+  ml/forecasting.py: bafybeiafpvnosan4ubm35tcl3wlxlro43nbx6hf5il6pn43f7win2hcsei
   ml/optimization.py: bafybeicyfabutvdyfvv2u3b6sdxfr4c5f7vvgvba4snovy5atx3zuj3nha
   ml/preprocessing.py: bafybeieha65b5cslcyyjobjupebyqovod7aigohdidcawz5b6tlxqxpruq
   models.py: bafybeibcj6txlpgjz6glp7poy7poseqvoirnyoi4qhsxgbhhkal6jx6jny
@@ -31,7 +31,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiab5la63tomj6272c727vo6fq2ltdatbbs4nglwj4te3ghdyli7sa
   tests/test_handlers.py: bafybeigcoykpzwmbh5hbwub3bx4lr4fwutstqmbjahqpwx3zwu5ing75de
   tests/test_ml/__init__.py: bafybeigluuyaz73cej42yohuvoxnrx65hqsqoqmpzgof4b7co246s3jxjy
-  tests/test_ml/test_forecasting.py: bafybeif3zrpv4cxiondiok7gutqq2er56bodsyjdoe4lvxwrjzb3udkhvi
+  tests/test_ml/test_forecasting.py: bafybeih6un4hazyym2al5qjbjvk2c3a6hdnlpgfcsw3abwlanw6oesglce
   tests/test_ml/test_optimization.py: bafybeihnvcgqttwmbi2idvmkrrd5becqry4bannzuww6webxfuznjocdfy
   tests/test_ml/test_preprocessing.py: bafybeicqer5b6fhzoimtrk4mwmh62km6olwljmhxvi6p7zdm6o4jbycfji
   tests/test_models.py: bafybeiaj6uv2dymuhmzqd3gqhdlheeoizzpdlmlemskqwci7q4dif4szxm

--- a/packages/valory/skills/apy_estimation_abci/tests/test_ml/test_forecasting.py
+++ b/packages/valory/skills/apy_estimation_abci/tests/test_ml/test_forecasting.py
@@ -342,7 +342,7 @@ class TestForecastingWithEstimator:
 
         mismatch = "test" if id_mismatch else ""
         pools_to_dummy_pipelines = {
-            pool_id + mismatch: deepcopy(dummy_pipeline)
+            "".join((pool_id, ".joblib", mismatch)): deepcopy(dummy_pipeline)
             for pool_id in prepare_batch_task_result["id"].values
         }
 

--- a/packages/valory/skills/apy_estimation_abci/tests/test_ml/test_forecasting.py
+++ b/packages/valory/skills/apy_estimation_abci/tests/test_ml/test_forecasting.py
@@ -346,21 +346,13 @@ class TestForecastingWithEstimator:
             for pool_id in prepare_batch_task_result["id"].values
         }
 
-        if mismatch:
-            update_forecaster_per_pool(
-                prepare_batch_task_result, pools_to_dummy_pipelines
-            )
-            assert not any(
-                pipeline.updated for pipeline in pools_to_dummy_pipelines.values()
-            )
+        update_forecaster_per_pool(prepare_batch_task_result, pools_to_dummy_pipelines)
+        updated = (pipeline.updated for pipeline in pools_to_dummy_pipelines.values())
 
+        if mismatch:
+            assert not any(updated)
         else:
-            update_forecaster_per_pool(
-                prepare_batch_task_result, pools_to_dummy_pipelines
-            )
-            assert all(
-                pipeline.updated for pipeline in pools_to_dummy_pipelines.values()
-            )
+            assert all(updated)
 
     @pytest.mark.parametrize("steps_forward", (0, 1, 5))
     def test_estimate_apy_per_pool(

--- a/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
@@ -25,7 +25,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy
-- valory/apy_estimation_abci:0.1.0:bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq
+- valory/apy_estimation_abci:0.1.0:bafybeianf55xqo3llhqedxzztvxwntue67jhagpwauu4t23ycox6fywiby
 - valory/registration_abci:0.1.0:bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm
 behaviours:
   main:

--- a/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
@@ -25,7 +25,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicwhcpuov2bvfwvzxdvmy6fhmijdhqi3uthee3bv4cfe7wm5fsbjy
-- valory/apy_estimation_abci:0.1.0:bafybeidzqjl6kbawjuh26gk7glcnhqifhqxs3rrli6i47r627en4dnhy5m
+- valory/apy_estimation_abci:0.1.0:bafybeicjelpu2ln5qail3b4tl6iuft62larz3lufigbznihtjtcpb7hmkq
 - valory/registration_abci:0.1.0:bafybeievtpfxmzrdueqgisebeqkefukvfhzhiczvmdnp4rerwup4v6karm
 behaviours:
   main:


### PR DESCRIPTION
## Proposed changes

We noticed that between re-training fresh models we were receiving the same estimates. This was happening because the model updates were failing and we could not detect this error because of https://github.com/valory-xyz/open-aea/issues/424.

The updates were failing because of incorrectly querying the ids from the data, assuming that they contained a `.csv` extension, which was not the case.

The test was implemented incorrectly because it was not passing the pipelines' input with the correct key names, i.e., the `.joblib` extension was not present. As a result, the method was not tested correctly as the `.csv` extension assumption was not being tested.

The test was fixed on de25faa4f86bb727fa9e9da4db3999393ab91678, which made the update method to fail. The next commits fix the issue.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a