### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,9 +19,9 @@ numpy = "==1.23.5"
 open-aea = {version = "==1.50.0", extras = ["all"]}
 open-aea-ledger-ethereum = "==1.50.0"
 open-aea-ledger-cosmos = "==1.50.0"
-open-aea-test-autonomy = "==0.14.9"
+open-aea-test-autonomy = "==0.14.10"
 open-aea-cli-ipfs = "==1.50.0"
-open-autonomy = {version = "==0.14.9", extras = ["all"]}
+open-autonomy = {version = "==0.14.10", extras = ["all"]}
 optuna = "==2.10.1"
 pandas = "==1.5.3"
 pandas-stubs = "==1.2.0.62"

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ In order to run a local demo of the ML APY Prediction Oracle service:
 2. Fetch the ML APY Prediction Oracle service.
 
 	```bash
-	autonomy fetch valory/apy_estimation:0.1.0:bafybeib54sggzlmv7d5n44cyncpd4nzpb4di4myc3m4w5vikwxdud7gwa4 --service
+	autonomy fetch valory/apy_estimation:0.1.0:bafybeicoddcqqaqqizpzjqg7p7k5hl2ygimutuhceoiafwu2zkecl57uru --service
 	```
 
 3. Build the Docker image of the service agents

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,9 +1,9 @@
 {
     "dev": {
-        "skill/valory/apy_estimation_abci/0.1.0": "bafybeih6ilpi25shhpvrzlbyrzn6jyvcfygmdpb7k4d4eahm37uspplupe",
-        "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeiegqap3wjxhawvoeg6h4nnhos5r2wrf72uugws7v4v53qec432rmu",
-        "agent/valory/apy_estimation/0.1.0": "bafybeid75fidnpz37oyi7icazmvpheipuxjtqvkubislcsjvgscmsbj7te",
-        "service/valory/apy_estimation/0.1.0": "bafybeib54sggzlmv7d5n44cyncpd4nzpb4di4myc3m4w5vikwxdud7gwa4"
+        "skill/valory/apy_estimation_abci/0.1.0": "bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu",
+        "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeif5m6h7haweybvxy3dbz4cdlu26uyhlfjxvv26xioiu62wlllydme",
+        "agent/valory/apy_estimation/0.1.0": "bafybeifvkwij7j5p2vszdyewlrpzpq3hzddtijtu7ckiqtp6bnfb7r25pq",
+        "service/valory/apy_estimation/0.1.0": "bafybeicoddcqqaqqizpzjqg7p7k5hl2ygimutuhceoiafwu2zkecl57uru"
     },
     "third_party": {
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
@@ -14,21 +14,21 @@
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeidrbrx5np67xc2rm5jvugplopeobawwqongp6meahhzzpzqsgolsu",
+        "contract/valory/service_registry/0.1.0": "bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeiafp7bu2ah3zypqyvpzkdvnwbjkr5cqt53zp3vrk6jqlcpntxqdia",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeig3vqcoxgp56uis3npzgbpfsgu4ku2t74ks6qsabzutacrmbziee4",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74",
         "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
-        "connection/valory/abci/0.1.0": "bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra",
+        "connection/valory/abci/0.1.0": "bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze",
         "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
         "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4",
-        "skill/valory/registration_abci/0.1.0": "bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4",
-        "skill/valory/termination_abci/0.1.0": "bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe"
+        "skill/valory/abstract_abci/0.1.0": "bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
+        "skill/valory/registration_abci/0.1.0": "bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
+        "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44"
     }
 }

--- a/packages/valory/agents/apy_estimation/aea-config.yaml
+++ b/packages/valory/agents/apy_estimation/aea-config.yaml
@@ -12,13 +12,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra
+- valory/abci:0.1.0:bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze
 - valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
 - valory/ipfs:0.1.0:bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii
 - valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- valory/service_registry:0.1.0:bafybeidrbrx5np67xc2rm5jvugplopeobawwqongp6meahhzzpzqsgolsu
+- valory/service_registry:0.1.0:bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/abci:0.1.0:bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u
@@ -29,14 +29,14 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 - valory/tendermint:0.1.0:bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra
 skills:
-- valory/abstract_abci:0.1.0:bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
-- valory/apy_estimation_abci:0.1.0:bafybeih6ilpi25shhpvrzlbyrzn6jyvcfygmdpb7k4d4eahm37uspplupe
-- valory/apy_estimation_chained_abci:0.1.0:bafybeiegqap3wjxhawvoeg6h4nnhos5r2wrf72uugws7v4v53qec432rmu
-- valory/registration_abci:0.1.0:bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a
-- valory/reset_pause_abci:0.1.0:bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu
-- valory/termination_abci:0.1.0:bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe
-- valory/transaction_settlement_abci:0.1.0:bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4
+- valory/abstract_abci:0.1.0:bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/apy_estimation_abci:0.1.0:bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu
+- valory/apy_estimation_chained_abci:0.1.0:bafybeif5m6h7haweybvxy3dbz4cdlu26uyhlfjxvv26xioiu62wlllydme
+- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
+- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
+- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
+- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -72,7 +72,7 @@ dependencies:
   open-aea-ledger-ethereum:
     version: ==1.50.0
   open-aea-test-autonomy:
-    version: ==0.14.9
+    version: ==0.14.10
 skill_exception_policy: just_log
 connection_exception_policy: just_log
 default_connection: null

--- a/packages/valory/services/apy_estimation/service.yaml
+++ b/packages/valory/services/apy_estimation/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibhbkelnxxvsln677imq65vgbglmlhyxtax4iqtzempjiwcoef3gq
 fingerprint_ignore_patterns: []
-agent: valory/apy_estimation:0.1.0:bafybeid75fidnpz37oyi7icazmvpheipuxjtqvkubislcsjvgscmsbj7te
+agent: valory/apy_estimation:0.1.0:bafybeifvkwij7j5p2vszdyewlrpzpq3hzddtijtu7ckiqtp6bnfb7r25pq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/apy_estimation_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_abci/skill.yaml
@@ -53,7 +53,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
 behaviours:
   main:
     args: {}
@@ -278,7 +278,7 @@ dependencies:
   numpy:
     version: ==1.23.5
   open-aea-test-autonomy:
-    version: ==0.14.9
+    version: ==0.14.10
   optuna:
     version: ==2.10.1
   pandas:

--- a/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
@@ -26,11 +26,11 @@ contracts: []
 protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
-- valory/apy_estimation_abci:0.1.0:bafybeih6ilpi25shhpvrzlbyrzn6jyvcfygmdpb7k4d4eahm37uspplupe
-- valory/registration_abci:0.1.0:bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a
-- valory/reset_pause_abci:0.1.0:bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu
-- valory/termination_abci:0.1.0:bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/apy_estimation_abci:0.1.0:bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu
+- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
+- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
+- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 behaviours:
   main:
     args: {}

--- a/setup.py
+++ b/setup.py
@@ -24,3 +24,4 @@ from setuptools import find_packages, setup  # type: ignore
 if __name__ == "__main__":
     setup(packages=[])
 
+

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ deps =
     hypothesis==6.21.6
     joblib==1.1.0
     open-aea-ledger-cosmos==1.50.0
-    open-aea-test-autonomy==0.14.9
-    open-autonomy[all]==0.14.9
+    open-aea-test-autonomy==0.14.10
+    open-autonomy[all]==0.14.10
     optuna==2.10.1
     pandas==1.5.3
     pandas-stubs==1.2.0.62
@@ -267,7 +267,7 @@ skipsdist = True
 usedevelop = True
 deps = 
     protobuf<4.25.0,>=4.21.6
-    open-autonomy[all]==0.14.9
+    open-autonomy[all]==0.14.10
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.50.0
- Bumps open-aea-ledger-ethereum to ==1.50.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.50.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.50.0
- Bumps open-aea-ledger-cosmos to ==1.50.0
- Bumps open-aea-ledger-solana to ==1.50.0
- Bumps open-aea-cli-ipfs to ==1.50.0
- Bumps open-autonomy to ==0.14.10
- Bumps open-aea-test-autonomy to ==0.14.10