### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,12 +16,12 @@ grpcio = "==1.53.0"
 hypothesis = "==6.21.6"
 joblib = "==1.1.0"
 numpy = "==1.23.5"
-open-aea = {version = "==1.50.0", extras = ["all"]}
-open-aea-ledger-ethereum = "==1.50.0"
-open-aea-ledger-cosmos = "==1.50.0"
-open-aea-test-autonomy = "==0.14.10"
-open-aea-cli-ipfs = "==1.50.0"
-open-autonomy = {version = "==0.14.10", extras = ["all"]}
+open-aea = {version = "==1.51.0", extras = ["all"]}
+open-aea-ledger-ethereum = "==1.51.0"
+open-aea-ledger-cosmos = "==1.51.0"
+open-aea-test-autonomy = "==0.14.11.post1"
+open-aea-cli-ipfs = "==1.51.0"
+open-autonomy = {version = "==0.14.11.post1", extras = ["all"]}
 optuna = "==2.10.1"
 pandas = "==1.5.3"
 pandas-stubs = "==1.2.0.62"

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,14 +16,14 @@ In order to run a local demo of the ML APY Prediction Oracle service:
     mkdir your_workspace && cd your_workspace
     touch Pipfile && pipenv --python 3.10 && pipenv shell
 
-    pipenv install open-autonomy[all]==0.14.6
+    pipenv install open-autonomy[all]==0.14.11.post1
     autonomy init --remote --ipfs --reset --author=your_name
     ```
 
 2. Fetch the ML APY Prediction Oracle service.
 
 	```bash
-	autonomy fetch valory/apy_estimation:0.1.0:bafybeicoddcqqaqqizpzjqg7p7k5hl2ygimutuhceoiafwu2zkecl57uru --service
+	autonomy fetch valory/apy_estimation:0.1.0:bafybeicsxwaemsw2v22n55zue3jwatxd462l44dlqwswgow7g7ekwsdaea --service
 	```
 
 3. Build the Docker image of the service agents

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,9 +1,9 @@
 {
     "dev": {
-        "skill/valory/apy_estimation_abci/0.1.0": "bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu",
-        "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeif5m6h7haweybvxy3dbz4cdlu26uyhlfjxvv26xioiu62wlllydme",
-        "agent/valory/apy_estimation/0.1.0": "bafybeifvkwij7j5p2vszdyewlrpzpq3hzddtijtu7ckiqtp6bnfb7r25pq",
-        "service/valory/apy_estimation/0.1.0": "bafybeicoddcqqaqqizpzjqg7p7k5hl2ygimutuhceoiafwu2zkecl57uru"
+        "skill/valory/apy_estimation_abci/0.1.0": "bafybeibzywrszknufplj2efjyn7wbiatfbugg37723si43yfgbdpfw5mdu",
+        "skill/valory/apy_estimation_chained_abci/0.1.0": "bafybeid6c6yqr3revoxsfc67v6g6vskr4wsej4arp6fceljrnaqzphleh4",
+        "agent/valory/apy_estimation/0.1.0": "bafybeicoz4vor7s67fi7j6g4iy2fa5i27pk5p65yye25xvg6tmb7ca4aki",
+        "service/valory/apy_estimation/0.1.0": "bafybeicsxwaemsw2v22n55zue3jwatxd462l44dlqwswgow7g7ekwsdaea"
     },
     "third_party": {
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
@@ -14,21 +14,21 @@
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm",
+        "contract/valory/service_registry/0.1.0": "bafybeigrfupd7lo6aet376rwluqgm33jfghibkbvumfsdgrymqxoopqydq",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74",
-        "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
-        "connection/valory/abci/0.1.0": "bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze",
-        "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
-        "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeiag5jjj5c66skkbjnxcjngeufhtcvcpnbnjlgox5mtuo2tk4w3ohi",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeiafghfcxrg3apccnrvvw7tfgjbopedbfevmhepw2reyhyertxrilm",
+        "connection/valory/ipfs/0.1.0": "bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna",
+        "connection/valory/abci/0.1.0": "bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa",
+        "connection/valory/http_client/0.23.0": "bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u",
+        "connection/valory/ledger/0.19.0": "bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
-        "skill/valory/registration_abci/0.1.0": "bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
-        "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44"
+        "skill/valory/abstract_abci/0.1.0": "bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy",
+        "skill/valory/registration_abci/0.1.0": "bafybeihwkqc6klqrk247esh4cumfphosx3yadullxhmrrkovzg2rward5y",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeibd5divbbng3klkxlkzfwmwdc7imobcymfx57lf3owbyf7we7xdem",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihfrdgfhu7ijjorvktjplfa4aq3b5as4dtwmkgl6nhy2oz4ayidfu",
+        "skill/valory/termination_abci/0.1.0": "bafybeifw36rnniyjay4f3af6jtfxpeycm5nu4zm4ejoutsk4yh2rv24ysm"
     }
 }

--- a/packages/valory/agents/apy_estimation/aea-config.yaml
+++ b/packages/valory/agents/apy_estimation/aea-config.yaml
@@ -12,13 +12,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze
-- valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
-- valory/ipfs:0.1.0:bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii
-- valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
+- valory/abci:0.1.0:bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa
+- valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
+- valory/ipfs:0.1.0:bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna
+- valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- valory/service_registry:0.1.0:bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm
+- valory/service_registry:0.1.0:bafybeigrfupd7lo6aet376rwluqgm33jfghibkbvumfsdgrymqxoopqydq
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/abci:0.1.0:bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u
@@ -29,14 +29,14 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 - valory/tendermint:0.1.0:bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra
 skills:
-- valory/abstract_abci:0.1.0:bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/apy_estimation_abci:0.1.0:bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu
-- valory/apy_estimation_chained_abci:0.1.0:bafybeif5m6h7haweybvxy3dbz4cdlu26uyhlfjxvv26xioiu62wlllydme
-- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
-- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
-- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
-- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
+- valory/abstract_abci:0.1.0:bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym
+- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
+- valory/apy_estimation_abci:0.1.0:bafybeibzywrszknufplj2efjyn7wbiatfbugg37723si43yfgbdpfw5mdu
+- valory/apy_estimation_chained_abci:0.1.0:bafybeid6c6yqr3revoxsfc67v6g6vskr4wsej4arp6fceljrnaqzphleh4
+- valory/registration_abci:0.1.0:bafybeihwkqc6klqrk247esh4cumfphosx3yadullxhmrrkovzg2rward5y
+- valory/reset_pause_abci:0.1.0:bafybeibd5divbbng3klkxlkzfwmwdc7imobcymfx57lf3owbyf7we7xdem
+- valory/termination_abci:0.1.0:bafybeifw36rnniyjay4f3af6jtfxpeycm5nu4zm4ejoutsk4yh2rv24ysm
+- valory/transaction_settlement_abci:0.1.0:bafybeihfrdgfhu7ijjorvktjplfa4aq3b5as4dtwmkgl6nhy2oz4ayidfu
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -68,11 +68,11 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-cosmos:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-ledger-ethereum:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11.post1
 skill_exception_policy: just_log
 connection_exception_policy: just_log
 default_connection: null

--- a/packages/valory/services/apy_estimation/service.yaml
+++ b/packages/valory/services/apy_estimation/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibhbkelnxxvsln677imq65vgbglmlhyxtax4iqtzempjiwcoef3gq
 fingerprint_ignore_patterns: []
-agent: valory/apy_estimation:0.1.0:bafybeifvkwij7j5p2vszdyewlrpzpq3hzddtijtu7ckiqtp6bnfb7r25pq
+agent: valory/apy_estimation:0.1.0:bafybeicoz4vor7s67fi7j6g4iy2fa5i27pk5p65yye25xvg6tmb7ca4aki
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/apy_estimation_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_abci/skill.yaml
@@ -53,7 +53,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
 behaviours:
   main:
     args: {}
@@ -278,7 +278,7 @@ dependencies:
   numpy:
     version: ==1.23.5
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11.post1
   optuna:
     version: ==2.10.1
   pandas:

--- a/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
+++ b/packages/valory/skills/apy_estimation_chained_abci/skill.yaml
@@ -26,11 +26,11 @@ contracts: []
 protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/apy_estimation_abci:0.1.0:bafybeieupzfuqd7iso34zdvnbz7s2mujj5ymnyunfsa2agp5qsmqzw24nu
-- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
-- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
-- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
+- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
+- valory/apy_estimation_abci:0.1.0:bafybeibzywrszknufplj2efjyn7wbiatfbugg37723si43yfgbdpfw5mdu
+- valory/registration_abci:0.1.0:bafybeihwkqc6klqrk247esh4cumfphosx3yadullxhmrrkovzg2rward5y
+- valory/reset_pause_abci:0.1.0:bafybeibd5divbbng3klkxlkzfwmwdc7imobcymfx57lf3owbyf7we7xdem
+- valory/termination_abci:0.1.0:bafybeifw36rnniyjay4f3af6jtfxpeycm5nu4zm4ejoutsk4yh2rv24ysm
 behaviours:
   main:
     args: {}
@@ -264,7 +264,7 @@ dependencies:
   numpy:
     version: ==1.23.5
   open-aea-cli-ipfs:
-    version: ==1.50.0
+    version: ==1.51.0
   optuna:
     version: ==2.10.1
   pandas:

--- a/setup.py
+++ b/setup.py
@@ -25,3 +25,4 @@ if __name__ == "__main__":
     setup(packages=[])
 
 
+

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,9 @@ deps =
     grpcio==1.53.0
     hypothesis==6.21.6
     joblib==1.1.0
-    open-aea-ledger-cosmos==1.50.0
-    open-aea-test-autonomy==0.14.10
-    open-autonomy[all]==0.14.10
+    open-aea-ledger-cosmos==1.51.0
+    open-aea-test-autonomy==0.14.11.post1
+    open-autonomy[all]==0.14.11.post1
     optuna==2.10.1
     pandas==1.5.3
     pandas-stubs==1.2.0.62
@@ -267,7 +267,7 @@ skipsdist = True
 usedevelop = True
 deps = 
     protobuf<4.25.0,>=4.21.6
-    open-autonomy[all]==0.14.10
+    open-autonomy[all]==0.14.11.post1
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync
@@ -657,7 +657,7 @@ fetchai-ledger-api: >=0.0.1
 chardet: >=3.0.4
 certifi: >=2019.11.28
 ;TODO: the following are conflicting packages that need to be sorted
-; sub-dep of open-aea-ledger-ethereum-hwi
+; sub-dep of open-aea-ledger-ethereum-hwi==1.51.0
 hidapi: >=0.13.2
 ; shows in pip freeze but not referenced on code
 paramiko: >=3.1.0


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.51.0
- Bumps open-aea-ledger-ethereum to ==1.51.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.51.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.51.0
- Bumps open-aea-ledger-cosmos to ==1.51.0
- Bumps open-aea-ledger-solana to ==1.51.0
- Bumps open-aea-cli-ipfs to ==1.51.0
- Bumps open-autonomy to ==0.14.11.post1
- Bumps open-aea-test-autonomy to ==0.14.11.post1